### PR TITLE
fix: make format now runs gofumpt

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -61,8 +61,12 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: "package.json"
-      - run: |
-          make format
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "go.mod"
+      - run: go install mvdan.cc/gofumpt@v0.7.0
+      - run: go install github.com/daixiang0/gci@v0.13.5
+      - run: make format
       - name: check diff
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ license-headers: ## Update license headers.
 		fi;
 
 .PHONY: format
-format: md-format yaml-format ## Format all files
+format: go-format md-format yaml-format ## Format all files
 
 .PHONY: md-format
 md-format: node_modules/.installed ## Format Markdown files.
@@ -147,7 +147,7 @@ go-format: ## Format Go files (gofumpt).
 	@set -euo pipefail;\
 		files=$$(git ls-files '*.go'); \
 		if [ "$${files}" != "" ]; then \
-			gofumpt $${files}; \
+			gofumpt -w $${files}; \
 			gci write  --skip-generated -s standard -s default -s "prefix(github.com/ianlewis/go-dictzip)" $${files}; \
 		fi
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Make `make format` run `go-format` using `gofumpt`

**Related Issues:**

Fixes #1

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
