### PR TITLE
fix: use default output format for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,12 +211,7 @@ yamllint: .venv/.installed ## Runs the yamllint linter.
 
 .PHONY: golangci-lint
 golangci-lint: ## Runs the golangci-lint linter.
-	@set -e;\
-		extraargs=""; \
-		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
-			extraargs="--out-format github-actions"; \
-		fi; \
-		golangci-lint run -c .golangci.yml ./... $$extraargs
+	@golangci-lint run -c .golangci.yml ./...
 
 ## Maintenance
 #####################################################################


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Don't use deprecated `github-actions` output format and just use the default `colored-line-reader`. GitHub Actions is able to parse this output format.

**Related Issues:**

Fixes #10 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
