### PR TITLE
fix: gci prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ go-format: ## Format Go files (gofumpt).
 		files=$$(git ls-files '*.go'); \
 		if [ "$${files}" != "" ]; then \
 			gofumpt -w $${files}; \
-			gci write  --skip-generated -s standard -s default -s "prefix(github.com/ianlewis/go-dictzip)" $${files}; \
+			gci write  --skip-generated -s standard -s default -s "prefix($$(go list -m))" $${files}; \
 		fi
 
 ## Linting


### PR DESCRIPTION
**Description:**

Fix the `gci` prefix in the `Makefile`

**Related Issues:**

Fixes #9

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
