### PR TITLE
chore: Remove install of gci and gofumpt

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -111,8 +111,6 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: "go.mod"
-      - run: go install mvdan.cc/gofumpt@v0.7.0
-      - run: go install github.com/daixiang0/gci@v0.13.5
       - run: make format
       - name: check diff
         run: |


### PR DESCRIPTION
**Description:**

Remove install of `gci` and `gofumpt` from the pre-submit test because these are installed via `make` and `aqua`.

**Related Issues:**

Fixes #58

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
