### PR TITLE
chore: Disable gocyclo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,7 +105,9 @@ linters:
     - ireturn # Accept Interfaces, Return Concrete Types.
     - lll # Reports long lines.
     - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
-    - maintidx # Maintidx measures the maintainability index of each function.
+    # NOTE: maintidx does not provide much value above other complexity
+    #       checkers.
+    # - maintidx # Maintidx measures the maintainability index of each function.
     - makezero # Finds slice declarations with non-zero initial length.
     - mirror # Reports wrong mirror patterns of bytes/strings usage.
     - misspell # Finds commonly misspelled English words.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,8 @@ linters:
     - gocognit # Computes and checks the cognitive complexity of functions.
     - goconst # Finds repeated strings that could be replaced by a constant.
     - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - gocyclo # Computes and checks the cyclomatic complexity of functions.
+    # NOTE: gocyclo overlaps in functionality with cyclop.
+    # - gocyclo # Computes and checks the cyclomatic complexity of functions.
     - godot # Check if comments end in a period.
     - godox # Detects usage of FIXME, TODO and other keywords inside comments.
     - gofmt # Checks if the code is formatted according to 'gofmt' command.
@@ -163,7 +164,8 @@ linters:
 linters-settings:
   cyclop:
     # Increased preserve some semblance of sanity.
-    max-complexity: 20
+    max-complexity: 30
+    package-average: 5.0
 
   depguard:
     rules:


### PR DESCRIPTION
**Description:**

Disable `gocyclo` since it overlaps in functionality with `cyclop`. Also disable `maintidx`.

**Related Issues:**

Fixes #56
Fixes #55 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
