### PR TITLE
chore: remove setting of PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,6 @@ go-format: $(AQUA_ROOT_DIR)/.installed ## Format Go files (gofumpt).
 		git ls-files --deduplicate \
 			'*.go' \
 	); \
-	PATH="$(REPO_ROOT)/.bin/aqua-$(AQUA_VERSION):$(AQUA_ROOT_DIR)/bin:$${PATH}"; \
-	AQUA_ROOT_DIR="$(AQUA_ROOT_DIR)"; \
 	if [ "$${files}" == "" ]; then \
 		exit 0; \
 	fi; \
@@ -382,8 +380,6 @@ fixme: $(AQUA_ROOT_DIR)/.installed ## Check for outstanding FIXMEs.
 .PHONY: golangci-lint
 golangci-lint: $(AQUA_ROOT_DIR)/.installed ## Runs the golangci-lint linter.
 	@# bash \
-	PATH="$(REPO_ROOT)/.bin/aqua-$(AQUA_VERSION):$(AQUA_ROOT_DIR)/bin:$${PATH}"; \
-	AQUA_ROOT_DIR="$(AQUA_ROOT_DIR)"; \
 	golangci-lint run -c .golangci.yml ./...
 
 .PHONY: markdownlint


### PR DESCRIPTION
**Description:**

The Aqua binaries directory is added to the `$PATH` globally so it doesn't need to be set in each `make` target anymore.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
